### PR TITLE
Feature/alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,16 @@ Auth should be in the "user:password" format.\
 - ```hubot mq stats``` - retrieves stats for broker
 - ```hubot mq queue stats``` - retrieves stats for all queues
 - ```hubot mq servers``` - lists all servers and queues attached to them.
+- ```hubot mq alert list``` - list all alerts and their statuses
+- ```hubot mq alert start <AlertNumber>``` - starts given alert.  use alert list to get id
+- ```hubot mq alert start``` - starts all alerts
+- ```hubot mq alert stop <AlertNumber>``` - stops given alert.  use alert list to get id
+- ```hubot mq alert stop``` - stops all alerts
+- ```hubot mq check <QueueName> every <X> <days|hours|minutes|seconds> and alert me when <queue size|consumer count> is (>|<|=|<=|>=|!=|<>) <Threshold>``` - Creates an alert that checks <QueueName> at time interval specified for conditions specified and alerts when conditions are met
 
-### Persistence **
+**NOTE: Alerts are currently dependent on the use of a channel id to send alerts (this is due to having to persist the data) and is currently supported with the Slack adapter**
+
+### Persistence
 Note: Various features will work best if the Hubot brain is configured to be persisted. By default
 the brain is an in-memory key/value store, but it can easily be configured to be persisted with Redis so
 data isn't lost when the process is restarted.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-active-mq",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-active-mq",
   "description": "Active MQ integration for Hubot with multiple server support",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "author": "Zack Hable <zack@cobaltdevteam.com>",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.6"
+	"node-schedule": "~1.3"
   },
   "devDependencies": {},
   "main": "index.coffee",


### PR DESCRIPTION
Added support for:

Alerts:
- Creation (hubot will check a queue periodically and send alerts when a threshold is set)
- Start/Stop/Delete
- Persistence (alerts will resume their last state automatically on launch)

Notes:
- The use of persistence for alerts depends on a channel id (where to send messages) and has only been tested on the Slack Adapter 
